### PR TITLE
errors during readiness check should not abort build execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
 - waiting for the selenium grid does not fail instantly if the grid api isn't up already (#13)
 
 ## [v2.1.0](https://github.com/cloudogu/zalenium-build-lib/releases/tag/v2.1.0) - 2020-12-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- waiting for the selenium grid does not fail instantly if the grid api isn't up already (#13)
+
 ## [v2.1.0](https://github.com/cloudogu/zalenium-build-lib/releases/tag/v2.1.0) - 2020-12-14
 
 ### Added

--- a/vars/withSelenium.groovy
+++ b/vars/withSelenium.groovy
@@ -107,7 +107,7 @@ void waitForSeleniumToGetReady(String host) {
 
 boolean isSeleniumReady(String host) {
     def result = sh(returnStdout: true,
-            script: "curl -sSL http://${host}/wd/hub/status") // Don't fail
+            script: "curl -sSL http://${host}/wd/hub/status || true") // Don't fail
     result.contains('ready\": true')
 }
 


### PR DESCRIPTION
This PR resolves #13 

`withSelenium` should work properly now even when the grid container is getting up delayed.